### PR TITLE
Fix bug in ShadowTranslate::_iterateClause().

### DIFF
--- a/src/Model/Behavior/ShadowTranslateBehavior.php
+++ b/src/Model/Behavior/ShadowTranslateBehavior.php
@@ -178,20 +178,19 @@ class ShadowTranslateBehavior extends TranslateBehavior
         $mainTableFields = $this->_mainFields();
         $joinRequired = false;
 
-        $clause->iterateParts(function ($c, $field) use ($fields, $alias, $mainTableAlias, $mainTableFields, &$joinRequired) {
+        $clause->iterateParts(function ($c, &$field) use ($fields, $alias, $mainTableAlias, $mainTableFields, &$joinRequired) {
             if (!is_string($field) || strpos($field, '.')) {
-                return;
+                return $c;
             }
 
             if (in_array($field, $fields)) {
                 $joinRequired = true;
                 $field = "$alias.$field";
-                return;
-            }
-
-            if (in_array($field, $mainTableFields)) {
+            } elseif (in_array($field, $mainTableFields)) {
                 $field = "$mainTableAlias.$field";
             }
+
+            return $c;
         });
 
         return $joinRequired;

--- a/tests/TestCase/Model/Behavior/ShadowTranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/ShadowTranslateBehaviorTest.php
@@ -4,6 +4,7 @@ namespace ShadowTranslate\Test\TestCase\Model\Behavior;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Cake\Test\TestCase\ORM\Behavior\TranslateBehaviorTest;
+use Cake\Utility\Hash;
 
 /**
  * ShadowTranslateBehavior test case
@@ -255,16 +256,19 @@ class ShadowTranslateBehaviorTest extends TranslateBehaviorTest
         $table->locale('eng');
 
         $article = $table->find('all')
-            ->order(['id' => 'asc'])
+            ->order(['id' => 'desc'])
+            ->hydrate(false)
             ->toArray();
 
-        $this->assertNotNull($article, 'There will be an exception if there\'s ambiguous sql');
+        $this->assertSame([3, 2, 1], Hash::extract($article, '{n}.id'));
 
         $article = $table->find('all')
             ->order(['title' => 'asc'])
+            ->hydrate(false)
             ->toArray();
 
-        $this->assertNotNull($article, 'There will be an exception if there\'s ambiguous sql');
+        $expected = ['Title #1', 'Title #2', 'Title #3'];
+        $this->assertSame($expected, Hash::extract($article, '{n}.title'));
     }
 
     /**


### PR DESCRIPTION
It was stripping out the order clause from query instead of aliasing fields.