### PR TITLE
Update ShadowTranslateBehavior.php

### DIFF
--- a/src/Model/Behavior/ShadowTranslateBehavior.php
+++ b/src/Model/Behavior/ShadowTranslateBehavior.php
@@ -6,7 +6,7 @@ use Cake\Database\Expression\FieldInterface;
 use Cake\Event\Event;
 use Cake\ORM\Behavior;
 use Cake\ORM\Behavior\TranslateBehavior;
-use Cake\ORM\Entity;
+use Cake\Datasource\EntityInterface;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
@@ -256,11 +256,11 @@ class ShadowTranslateBehavior extends TranslateBehavior
      * in the database too.
      *
      * @param \Cake\Event\Event $event The beforeSave event that was fired
-     * @param \Cake\ORM\Entity $entity The entity that is going to be saved
+     * @param \Cake\Datasource\EntityInterface $entity The entity that is going to be saved
      * @param \ArrayObject $options the options passed to the save method
      * @return void
      */
-    public function beforeSave(Event $event, Entity $entity, ArrayObject $options)
+    public function beforeSave(Event $event, EntityInterface $entity, ArrayObject $options)
     {
         $locale = $entity->get('_locale') ?: $this->locale();
         $table = $this->_config['translationTable'];

--- a/src/Model/Behavior/ShadowTranslateBehavior.php
+++ b/src/Model/Behavior/ShadowTranslateBehavior.php
@@ -135,7 +135,9 @@ class ShadowTranslateBehavior extends TranslateBehavior
      */
     protected function _addFieldsToQuery(Query $query, array $config)
     {
-        $select = $query->clause('select');
+        $select = array_filter($query->clause('select'), function ($field) {
+            return is_string($field);
+        });
 
         if (!$select) {
             return true;

--- a/tests/TestCase/Model/Behavior/ShadowTranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/ShadowTranslateBehaviorTest.php
@@ -604,7 +604,7 @@ class ShadowTranslateBehaviorTest extends TranslateBehaviorTest
         
         $query->select(['title', 'title2' => $query->func()->concat(['title' => 'literal', ' 2']), 'body']);
 
-        $this->assertNotNull(query->toArrat(), 'There will be an exception if there\'s field type problem');
+        $this->assertNotNull($query->toArray(), 'There will be an exception if there\'s field type problem');
         
 
         $expected = ['title', 'body'];

--- a/tests/TestCase/Model/Behavior/ShadowTranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/ShadowTranslateBehaviorTest.php
@@ -603,6 +603,8 @@ class ShadowTranslateBehaviorTest extends TranslateBehaviorTest
         $query = $table->find();
         
         $query->select(['title', 'title2' => $query->func()->concat(['title' => 'literal', ' 2']), 'body']);
+
+        $this->assertNotNull(query->toArrat(), 'There will be an exception if there\'s field type problem');
         
 
         $expected = ['title', 'body'];

--- a/tests/TestCase/Model/Behavior/ShadowTranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/ShadowTranslateBehaviorTest.php
@@ -602,7 +602,7 @@ class ShadowTranslateBehaviorTest extends TranslateBehaviorTest
         $table->locale('eng');
         $query = $table->find();
         
-        $query->select(['title', 'title2' => $query->func()->concat(['title' => 'literal', ' 2']), 'body']);
+        $query->select(['title', 'title2' => $query->func()->concat(['Articles.title' => 'literal', ' 2']), 'body']);
 
         $this->assertNotNull($query->toArray(), 'There will be an exception if there\'s field type problem');
         

--- a/tests/TestCase/Model/Behavior/ShadowTranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/ShadowTranslateBehaviorTest.php
@@ -588,6 +588,31 @@ class ShadowTranslateBehaviorTest extends TranslateBehaviorTest
         $this->assertSame('First Article Body', $result->body, 'The empty translation should be ignored');
         $this->assertNull($result->description);
     }
+    
+    /**
+     * Tests using FunctionExpression
+     *
+     * @return void
+     */
+    public function testUsingFunctionExpression()
+    {
+        $table = TableRegistry::get('Articles');
+        $table->addBehavior('Translate');
+
+        $table->locale('eng');
+        $query = $table->find();
+        
+        $query->select(['title', 'title2' => $query->func()->concat(['title' => 'literal', ' 2']), 'body']);
+        
+
+        $expected = ['title', 'body'];
+        $result = $table->behaviors()->get('ShadowTranslate')->config('fields');
+        $this->assertSame(
+            $expected,
+            $result,
+            'If no fields are specified, they should be derived from the schema'
+        );
+    }
 
     /**
      * Used in the config tests to verify that a simple find still works


### PR DESCRIPTION
Fixed a problem with FunctionExpression in select clause, that causes
Catchable fatal error: Object of class Cake\Database\Expression\FunctionExpression could not be converted to string in .../vendor/ad7six/shadow-translate/src/Model/Behavior/ShadowTranslateBehavior.php on line 147