### PR TITLE
Fix accessible

### DIFF
--- a/src/Model/Behavior/ShadowTranslateBehavior.php
+++ b/src/Model/Behavior/ShadowTranslateBehavior.php
@@ -418,7 +418,7 @@ class ShadowTranslateBehavior extends TranslateBehavior
                     'id' => $key,
                     'locale' => $lang,
                 ];
-                $translation->set($update, ['setter' => false]);
+                $translation->set($update, ['guard' => false]);
             }
         }
 

--- a/tests/TestCase/Model/Behavior/BakedArticles.php
+++ b/tests/TestCase/Model/Behavior/BakedArticles.php
@@ -1,0 +1,19 @@
+<?php
+namespace ShadowTranslate\Test\TestCase\Model\Behavior;
+
+use Cake\ORM\Entity;
+use Cake\ORM\Behavior\Translate\TranslateTrait;
+
+/**
+ * Simulated baked entity class for a translated table
+ *
+ */
+class BakedArticles extends Entity
+{
+    use TranslateTrait;
+
+    protected $_accessible = [
+        'title' => true,
+        'body' => true
+    ];
+}

--- a/tests/TestCase/Model/Behavior/BakedArticles.php
+++ b/tests/TestCase/Model/Behavior/BakedArticles.php
@@ -1,8 +1,8 @@
 <?php
 namespace ShadowTranslate\Test\TestCase\Model\Behavior;
 
-use Cake\ORM\Entity;
 use Cake\ORM\Behavior\Translate\TranslateTrait;
+use Cake\ORM\Entity;
 
 /**
  * Simulated baked entity class for a translated table

--- a/tests/TestCase/Model/Behavior/ShadowTranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/ShadowTranslateBehaviorTest.php
@@ -640,9 +640,9 @@ class ShadowTranslateBehaviorTest extends TranslateBehaviorTest
         $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
 
         $article = $table->get(1);
-
         $article->translation('xyz')->title = 'XYZ title';
-        $table->save($article);
+
+        $this->assertNotFalse($table->save($article), "The save should succeed");
     }
 
     /**

--- a/tests/TestCase/Model/Behavior/ShadowTranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/ShadowTranslateBehaviorTest.php
@@ -29,7 +29,7 @@ class ShadowTranslateBehaviorTest extends TranslateBehaviorTest
     public function setUp()
     {
         $aliases = ['Articles', 'Authors', 'Comments'];
-        $options = ['className' => 'ShadowTranslate\Test\TestCase\Model\Behavior\Table'];
+        $options = ['className' => __NAMESPACE__ . '\Table'];
 
         foreach ($aliases as $alias) {
             TableRegistry::get($alias, $options);
@@ -622,6 +622,27 @@ class ShadowTranslateBehaviorTest extends TranslateBehaviorTest
             $result,
             'Including a function expression should work but requires referencing the used table aliases'
         );
+    }
+
+    /**
+     * Ensure saving with accessible defined works
+     *
+     * With a standard baked model the accessible property is defined, that'll mean that
+     * Setting fields such as id and locale will fail by default due to mass-assignment
+     * protection. An exception is thrown if that happens
+     *
+     * @return void
+     */
+    public function testSaveWithAccessibleFalse()
+    {
+        $table = TableRegistry::get('Articles');
+        $table->entityClass(__NAMESPACE__ . '\BakedArticles');
+        $table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+
+        $article = $table->get(1);
+
+        $article->translation('xyz')->title = 'XYZ title';
+        $table->save($article);
     }
 
     /**


### PR DESCRIPTION
Creating translations fails if the accessible property of the main entity is defined. This is due to the core translate trait, which this behavior uses, [creating translation records using the same class as the main entity](https://github.com/cakephp/cakephp/blob/master/src/ORM/Behavior/Translate/TranslateTrait.php#L50-L52)

I have been quietly wondering why debug output shows this:

```
'id' => '6112de76-32d9-4fed-955c-64766813af54',
'title' => 'default title',
'description' => 'some description',
'link' => '/test1',
'_translations' => [
    'es_CA' => object(App\Model\Entity\HomeBanner) { <- Not a FooTranslation
```

when the translate trait is used without realising this was the reason. So, that means the translation entity has the same accessible property as the main entity - which if it's anything other than * would fail to set the primary key field values.

Closes https://github.com/AD7six/cakephp-shadow-translate/issues/19 https://github.com/AD7six/cakephp-shadow-translate/issues/20