### PR TITLE
Alias for translation was incorrect

### DIFF
--- a/src/Model/Behavior/ShadowTranslateBehavior.php
+++ b/src/Model/Behavior/ShadowTranslateBehavior.php
@@ -225,7 +225,6 @@ class ShadowTranslateBehavior extends TranslateBehavior
         $fields = $this->_translationFields();
         $mainTableAlias = $config['mainTableAlias'];
         $mainTableFields = $this->_mainFields();
-        $alias = $config['referenceName'];
         $joinRequired = false;
 
         $clause->traverse(function ($expression) use ($fields, $alias, $mainTableAlias, $mainTableFields, &$joinRequired) {


### PR DESCRIPTION
The $alias define at twice position.
The first time is correct but the second not.
Remove "$alias = $config['referenceName'];" at 228 from _traverseClause and the process is OK
