### PR TITLE
Dont intersect translation fields with the query select fields

### DIFF
--- a/src/Model/Behavior/ShadowTranslateBehavior.php
+++ b/src/Model/Behavior/ShadowTranslateBehavior.php
@@ -142,14 +142,11 @@ class ShadowTranslateBehavior extends TranslateBehavior
         if (!$select) {
             return true;
         }
-
-        $alias = $config['mainTableAlias'];
+        
         $joinRequired = false;
         foreach ($this->_translationFields() as $field) {
-            if (array_intersect($select, [$field, "$alias.$field"])) {
                 $joinRequired = true;
                 $query->select($query->aliasField($field, $config['hasOneAlias']));
-            }
         }
 
         if ($joinRequired) {

--- a/src/Model/Behavior/ShadowTranslateBehavior.php
+++ b/src/Model/Behavior/ShadowTranslateBehavior.php
@@ -34,6 +34,10 @@ class ShadowTranslateBehavior extends TranslateBehavior
             $tableReferenceName = $this->_referenceName($table);
         }
 
+        if (empty($config['translateAllFields'])) {
+            $config['translateAllFields'] = false;
+        }
+
         $config += [
             'mainTableAlias' => $tableAlias,
             'translationTable' => $plugin . $tableReferenceName . 'Translations',
@@ -142,11 +146,14 @@ class ShadowTranslateBehavior extends TranslateBehavior
         if (!$select) {
             return true;
         }
-        
+
+        $alias = $config['mainTableAlias'];
         $joinRequired = false;
         foreach ($this->_translationFields() as $field) {
+            if (array_intersect($select, [$field, "$alias.$field"]) || $config['translateAllFields']) {
                 $joinRequired = true;
                 $query->select($query->aliasField($field, $config['hasOneAlias']));
+            }
         }
 
         if ($joinRequired) {


### PR DESCRIPTION
I have a problem with retrieving the fields that need to be translated from the query in addFieldsToQuery method, so I made it always to take all translation fields for the model.
I have described the problem here -  https://goo.gl/ht9XNi .