### PR TITLE
Fix error when using plugin's table.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,14 +31,11 @@ matrix:
 
 before_script:
   - composer self-update
-  - composer install --no-interaction --dev
+  - composer install --no-interaction --prefer-source
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi"
   - sh -c "if [ '$COVERALLS' = '1' ]; then composer require --dev satooshi/php-coveralls:dev-master; fi"
   - sh -c "if [ '$COVERALLS' = '1' ]; then mkdir -p build/logs; fi"
-
-  - phpenv rehash
-  - set +H
 
 script:
   - sh -c "if [ '$DEFAULT' = '1' ]; then phpunit --stderr; fi"

--- a/src/Model/Behavior/ShadowTranslateBehavior.php
+++ b/src/Model/Behavior/ShadowTranslateBehavior.php
@@ -262,8 +262,7 @@ class ShadowTranslateBehavior extends TranslateBehavior
     public function beforeSave(Event $event, EntityInterface $entity, ArrayObject $options)
     {
         $locale = $entity->get('_locale') ?: $this->locale();
-        $table = $this->_config['translationTable'];
-        $newOptions = [$table => ['validate' => false]];
+        $newOptions = [$this->_table->alias() => ['validate' => false]];
         $options['associated'] = $newOptions + $options['associated'];
 
         $this->_bundleTranslatedFields($entity);

--- a/src/Model/Behavior/ShadowTranslateBehavior.php
+++ b/src/Model/Behavior/ShadowTranslateBehavior.php
@@ -262,7 +262,7 @@ class ShadowTranslateBehavior extends TranslateBehavior
     public function beforeSave(Event $event, EntityInterface $entity, ArrayObject $options)
     {
         $locale = $entity->get('_locale') ?: $this->locale();
-        $newOptions = [$this->_table->alias() => ['validate' => false]];
+        $newOptions = [$this->_translationTable->alias() => ['validate' => false]];
         $options['associated'] = $newOptions + $options['associated'];
 
         $this->_bundleTranslatedFields($entity);


### PR DESCRIPTION
Without this fix when adding the behavior to a table within plugin,
it tries to save with key 'Plugin.SomeTable' in $options['associated'] which
ends up throwing and error "Cannot save Plugin.SomeModelTranslations, it is not
associated to SomeModel".