### PR TITLE
Fix bug and added tests

### DIFF
--- a/src/Model/Behavior/ShadowTranslateBehavior.php
+++ b/src/Model/Behavior/ShadowTranslateBehavior.php
@@ -135,6 +135,10 @@ class ShadowTranslateBehavior extends TranslateBehavior
      */
     protected function _addFieldsToQuery(Query $query, array $config)
     {
+        if ($query->autoFields()) {
+            return true;
+        }
+
         $select = array_filter($query->clause('select'), function ($field) {
             return is_string($field);
         });

--- a/tests/Fixture/TagsTranslationsFixture.php
+++ b/tests/Fixture/TagsTranslationsFixture.php
@@ -1,0 +1,40 @@
+<?php
+namespace ShadowTranslate\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * Class TagsTranslationsFixture
+ *
+ */
+class TagsTranslationsFixture extends TestFixture
+{
+    /**
+     * fields property
+     *
+     * @var array
+     */
+    public $fields = [
+        'id' => ['type' => 'integer'],
+        'locale' => ['type' => 'string', 'null' => false],
+        'name' => ['type' => 'string', 'null' => false],
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id', 'locale']]],
+    ];
+
+    /**
+     * records property
+     *
+     * @var array
+     */
+    public $records = [
+        ['locale' => 'eng', 'id' => 1, 'name' => 'tag1 in eng'],
+        ['locale' => 'deu', 'id' => 1, 'name' => 'tag1 in deu'],
+        ['locale' => 'cze', 'id' => 1, 'name' => 'tag1 in cze'],
+        ['locale' => 'eng', 'id' => 2, 'name' => 'tag2 in eng'],
+        ['locale' => 'deu', 'id' => 2, 'name' => 'tag2 in deu'],
+        ['locale' => 'cze', 'id' => 2, 'name' => 'tag2 in cze'],
+        ['locale' => 'eng', 'id' => 3, 'name' => 'tag3 in eng'],
+        ['locale' => 'deu', 'id' => 3, 'name' => 'tag3 in deu'],
+        ['locale' => 'cze', 'id' => 3, 'name' => 'tag3 in cze'],
+    ];
+}

--- a/tests/TestCase/Model/Behavior/ShadowTranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/ShadowTranslateBehaviorTest.php
@@ -549,7 +549,6 @@ class ShadowTranslateBehaviorTest extends TranslateBehaviorTest
      */
     public function testFindWithBTMAssociations()
     {
-
         $Articles = TableRegistry::get('Articles');
         $Tags = TableRegistry::get('Tags');
 

--- a/tests/TestCase/Model/Behavior/ShadowTranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/ShadowTranslateBehaviorTest.php
@@ -15,10 +15,13 @@ class ShadowTranslateBehaviorTest extends TranslateBehaviorTest
         'core.Articles',
         'core.Authors',
         'core.Comments',
+        'core.Tags',
+        'core.ArticlesTags',
         'plugin.ShadowTranslate.ArticlesTranslations',
         'plugin.ShadowTranslate.ArticlesMoreTranslations',
         'plugin.ShadowTranslate.AuthorsTranslations',
         'plugin.ShadowTranslate.CommentsTranslations',
+        'plugin.ShadowTranslate.TagsTranslations',
     ];
 
     /**
@@ -536,6 +539,58 @@ class ShadowTranslateBehaviorTest extends TranslateBehaviorTest
         $this->assertSame($expected, $result->author->toArray());
 
         $this->assertNotEmpty($result->_translations, "Translations can't be empty.");
+    }
+
+
+    /**
+     * Test that when finding BTM associations, the contained BTM data is also translated.
+     *
+     * @return void
+     */
+    public function testFindWithBTMAssociations()
+    {
+
+        $Articles = TableRegistry::get('Articles');
+        $Tags = TableRegistry::get('Tags');
+
+        $Articles->addBehavior('ShadowTranslate.ShadowTranslate');
+        $Tags->addBehavior('ShadowTranslate.ShadowTranslate');
+
+        $Articles->locale('deu');
+        $Tags->locale('deu');
+
+        $Articles->belongsToMany('Tags');
+
+        $query = $Articles
+            ->find()
+            ->where(['Articles.id' => 1])
+            ->contain(['Tags']);
+
+        $result = $query->firstOrFail();
+
+        $this->assertCount(2, $result->tags, "There should be two translated tags.");
+
+        $expected = [
+            'id' => 1,
+            'name' => 'tag1 in deu',
+            '_locale' => 'deu',
+            '_joinData' => [
+                'tag_id' => 1,
+                'article_id' => 1
+            ]
+        ];
+        $this->assertSame($expected, $result->tags[0]->toArray());
+
+        $expected = [
+            'id' => 2,
+            'name' => 'tag2 in deu',
+            '_locale' => 'deu',
+            '_joinData' => [
+                'tag_id' => 2,
+                'article_id' => 1
+            ]
+        ];
+        $this->assertSame($expected, $result->tags[1]->toArray());
     }
 
     /**


### PR DESCRIPTION
As explained in the documentation of the ```ShadowTranslateBehavior::_addFieldsToQuery()``` function:

> If the query is using autofields (directly or implicitly) add the main table's fields to the query first.

Checking if autoFields is being used (it's possible to both have specified fields in the select clause AND autoFields set to true) is never done, so eg. in a contained BTM association where the junctionTable fields are added to the query, the primary tables fields are never checked, the translation is never done on the BTM association.

This commit fixes that, by checking if the autoFields is true or false in the addFields function.