### PR TITLE
Fix saving of multiple translations using "_translations" key in data.

### DIFF
--- a/src/Model/Behavior/ShadowTranslateBehavior.php
+++ b/src/Model/Behavior/ShadowTranslateBehavior.php
@@ -346,6 +346,16 @@ class ShadowTranslateBehavior extends TranslateBehavior
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function buildMarshalMap($marshaller, $map, $options)
+    {
+        $this->_translationFields();
+
+        return parent::buildMarshalMap($marshaller, $map, $options);
+    }
+
+    /**
      * Returns a fully aliased field name for translated fields.
      *
      * If the requested field is configured as a translation field, field with

--- a/tests/TestCase/Model/Behavior/ShadowTranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/ShadowTranslateBehaviorTest.php
@@ -987,6 +987,40 @@ class ShadowTranslateBehaviorTest extends TranslateBehaviorTest
     }
 
     /**
+     * Test buildMarshalMap() builds new entities.
+     *
+     * @return void
+     */
+    public function testBuildMarshalMapBuildEntities()
+    {
+        $table = TableRegistry::get('Articles');
+        // Unlike test case of core Translate behavior "fields" is not set to
+        // test marshalling with lazily fetched fields list.
+        $table->addBehavior('Translate');
+        $translate = $table->behaviors()->get('Translate');
+
+        $map = $translate->buildMarshalMap($table->marshaller(), [], []);
+        $entity = $table->newEntity();
+        $data = [
+            'en' => [
+                'title' => 'English Title',
+                'body' => 'English Content'
+            ],
+            'es' => [
+                'title' => 'Titulo Español',
+                'body' => 'Contenido Español'
+            ]
+        ];
+        $result = $map['_translations']($data, $entity);
+        $this->assertEmpty($entity->errors(), 'No validation errors.');
+        $this->assertCount(2, $result);
+        $this->assertArrayHasKey('en', $result);
+        $this->assertArrayHasKey('es', $result);
+        $this->assertEquals('English Title', $result['en']->title);
+        $this->assertEquals('Titulo Español', $result['es']->title);
+    }
+
+    /**
      * Used in the config tests to verify that a simple find still works
      *
      * @param string $tableAlias


### PR DESCRIPTION
TranslateBehavior::buildMarshalMap() uses the "fields" config and since
ShadowTranslateBehavior gets translated fields list lazily it was not working as expected.