### PR TITLE
Stop using deprecated methods and bump to cake 3.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
         }
     ],
     "require": {
-        "cakephp/orm": "^3.5",
-        "cakephp/i18n": "^3.5"
+        "cakephp/orm": "^3.8",
+        "cakephp/i18n": "^3.8"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7.14|^6.0",
-        "cakephp/cakephp": "^3.5",
+        "cakephp/cakephp": "^3.8",
         "cakephp/cakephp-codesniffer": "^3.0"
     },
     "autoload": {

--- a/src/Model/Behavior/ShadowTranslateBehavior.php
+++ b/src/Model/Behavior/ShadowTranslateBehavior.php
@@ -457,7 +457,7 @@ class ShadowTranslateBehavior extends TranslateBehavior
 
             $translation = $row['translation'];
 
-            $keys = $hydrated ? $translation->visibleProperties() : array_keys($translation);
+            $keys = $hydrated ? $translation->getVisible() : array_keys($translation);
 
             foreach ($keys as $field) {
                 if ($field === 'locale') {


### PR DESCRIPTION
https://api.cakephp.org/3.8/class-Cake.Datasource.EntityTrait.html#_getVisible has replaced https://api.cakephp.org/3.8/class-Cake.Datasource.EntityTrait.html#_visibleProperties in `3.8.0` :) 